### PR TITLE
Pass the option -fPIC to the liblmdb makefile to avoid having to modify the liblmdb Makefile

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -174,7 +174,7 @@ sub MY::postamble {
 $(MYEXTLIB): liblmdb/Makefile
 @[
 	cd liblmdb
-	$(MAKE) liblmdb$(LIB_EXT)
+	$(MAKE) XCFLAGS=-fPIC liblmdb$(LIB_EXT)
 	cd ..
 ]
 EOT
@@ -182,14 +182,14 @@ EOT
 		return <<'EOT';
 $(MYEXTLIB): liblmdb/Makefile
 	cd liblmdb
-	$(MAKE) liblmdb$(LIB_EXT)
+	$(MAKE) XCFLAGS=-fPIC liblmdb$(LIB_EXT)
 	cd ..
 EOT
-	    } 
+	    }
 	} else {
 	    return <<'EOT';
 $(MYEXTLIB): liblmdb/Makefile
-	cd liblmdb && $(MAKE) liblmdb$(LIB_EXT)
+	cd liblmdb && $(MAKE) XCFLAGS=-fPIC liblmdb$(LIB_EXT)
 EOT
 	}
     }


### PR DESCRIPTION
When trying to compile against a virgin liblmdb I received the following error.
/usr/bin/ld: liblmdb/liblmdb.a(mdb.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a shared object; recompile with -fPIC

So in order to avoid having to modify the lmdb/Makefile every time I passed the -fPIC option