### PR TITLE
locale fix [RT #111305]

### DIFF
--- a/t/01-environment.t
+++ b/t/01-environment.t
@@ -8,10 +8,8 @@ use Encode;
 use File::Temp;
 use LMDB_File qw(:envflags :cursor_op);
 
-if($ENV{LANG} && $ENV{LANG} !~ /^en/) {
-    # The tests needs 'C' LC_MESSAGES
-    eval { require POSIX; POSIX::setlocale(POSIX::LC_MESSAGES(), 'C'); }
-}
+# The tests needs 'C' LC_MESSAGES
+eval { require POSIX; POSIX::setlocale(POSIX::LC_ALL(), 'C'); };
 
 throws_ok {
     LMDB::Env->new("NoSuChDiR");


### PR DESCRIPTION
Instead of checking for the setting of LANG (but not LC_ALL,
LC_MESSAGES, and LANGUAGE) and changing only LC_MESSAGES,
set unconditionally LC_ALL, which has the highest precedence
of all locale variables.