### PR TITLE
Fix tests on ppc64[le] architecture

### DIFF
--- a/t/01-environment.t
+++ b/t/01-environment.t
@@ -1,7 +1,7 @@
 #!perl
 use strict;
 use warnings;
-use Test::More tests => 175;
+use Test::More tests => 174;
 use Test::Exception;
 use Encode;
 
@@ -55,7 +55,8 @@ throws_ok {
     isa_ok(my $stat = $env->stat, 'HASH', 'Get Stat');
     ok(exists $stat->{$_}, "Stat has $_")
 	for qw(psize depth branch_pages leaf_pages overflow_pages entries);
-    is($stat->{psize}, 4096, 'Default psize');
+    # psize differs on various platforms
+    #is($stat->{psize}, 4096, 'Default psize');
     is($stat->{$_}, 0, "$_ = 0, empty")
 	for qw(depth branch_pages leaf_pages overflow_pages entries);
 

--- a/t/03-fastmode.t
+++ b/t/03-fastmode.t
@@ -19,7 +19,9 @@ ok(-d $dir, "Created test dir $dir");
 my $large1 = '0123456789' x 100_000;
 my $val;
 {
-    my $env = LMDB::Env->new($dir);
+    my $env = LMDB::Env->new($dir, {
+        mapsize => 100 * 1024 * 1024
+    });
     ok(my $DB = $env->BeginTxn->OpenDB, 'Open unamed');
     is($DB->dbi, 1, 'Opened');
     is($DB->put('A' => $large1), $large1, 'Put large value');


### PR DESCRIPTION
Removed test that checks default page size, because it is not consistent for all platforms, this default value should be somehow determined out of this library.

Increased map size of database, because on ppc64 it is not able to store 1MB of data into 1MB big database. 
This could be a bug. If on x86_64 it is able to store 1MB to 1MB big database but not possible on ppc64[le].

Solves issue #28.