### PR TITLE
Update LMDB.xs

### DIFF
--- a/LMDB.xs
+++ b/LMDB.xs
@@ -115,7 +115,7 @@ populateStat(pTHX_ HV** hashptr, int res, MDB_stat *stat)
 {
     HV* RETVAL;
     if(res)
-	croak(mdb_strerror(res));
+	croak("%s",mdb_strerror(res));
     RETVAL = newHV();
     StoreUV("psize", stat->ms_psize);
     StoreUV("depth", stat->ms_depth);


### PR DESCRIPTION
LMDB_File incorrectly uses croak() and that can lead to a crash and produces a warning (or a compilation error) with Perl 5.28.0 now. Attached patch fixes it.  Per bug report on cpan.