### PR TITLE
Fix FTBFS on 32-bit with gcc 14

### DIFF
--- a/LMDB.xs
+++ b/LMDB.xs
@@ -901,7 +901,7 @@ mdb_cursor_close(cursor)
 int
 mdb_cursor_count(cursor, count)
 	LMDB::Cursor	cursor
-	UV  &count = NO_INIT
+	size_t  &count = NO_INIT
     OUTPUT:
 	count
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to LMDB_File.
We thought you might be interested in it too.

    Description: Fix FTBFS on 32-bit with gcc 14
    Bug-Debian: https://bugs.debian.org/1085133
    Author: Adrian Bunk <bunk@debian.org>
    Reviewed-by: gregor herrmann <gregoa@debian.org>
    Last-Update: 2024-10-15
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/liblmdb-file-perl/raw/master/debian/patches/1002_gcc-14.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
